### PR TITLE
Don't use 'tmp' dir when sharing a single file

### DIFF
--- a/read_from_working_copy_app.py
+++ b/read_from_working_copy_app.py
@@ -13,7 +13,10 @@ def main():
         file_paths = appex.get_file_paths()
         assert len(file_paths) == 1, 'Invalid file paths: {}'.format(file_paths)
         srce_path = file_paths[0]
-        dest_path = srce_path.split('/tmp/')[-1]
+        if '/tmp/' in srce_path:
+            dest_path = srce_path.split('/tmp/')[-1]
+        else:
+            dest_path = srce_path.split('/Repositories/')[-1]
         dest_path = os.path.join(from_wc, dest_path)
         file_path, file_name = os.path.split(dest_path)
         if not os.path.exists(file_path):


### PR DESCRIPTION
The file paths are different when sharing a single file and whole repository. While sharing a repository, Working Copy zip its contents and store the .zip file in 'tmp' directory. As for sharing a single file, Working Copy does not use 'tmp' directory. In this commit the script checks if 'tmp' is in file path pattern to get the correct basename.